### PR TITLE
Set process.env.NODE_ENV='local' to not use SSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,6 @@ provider:
       Resource:
         - 'Fn::Sub': 'arn:aws:kms:us-east-1:${AWS::AccountId}:key/<your-kms-key>'
 ```
+
+# Developing locally
+If you use `sreda` while developing locally, you can set `process.env.NODE_ENV = 'local'` and use the environment variables set in `process.env`.

--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -37,7 +37,6 @@ ssm = { getParameters: () => { return ssmPromise } }
 
 describe('mock AWS.SSM()', () => {
   beforeAll(async () => {
-    process.env.NODE_ENV = 'production'
   })
 
   it(`throws an error if SSM is not provided`, async () => {
@@ -99,8 +98,8 @@ describe('mock AWS.SSM()', () => {
     expect(configResponse).toHaveProperty('onRefreshError')
   })
 
-  it(`uses process.env when not in production`, async () => {
-    process.env.NODE_ENV = 'development'
+  it(`uses process.env locally`, async () => {
+    process.env.NODE_ENV = 'local'
     process.env.foo = 'foodev'
     process.env.bar = 'bardev'
     expect(await keys(ssm, ['foo', 'bar'])).toEqual({

--- a/lib/config.js
+++ b/lib/config.js
@@ -33,7 +33,7 @@ const read = (ssm, keys, expiryMs = DEFAULT_EXPIRY) => {
 
   const fetchParams = async () => {
     let params = {}
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV !== 'local') {
       const request = {
         Names: keys,
         WithDecryption: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sreda",
-  "version": "0.0.2-dev",
+  "version": "0.0.3-dev",
   "description": "Read your env variables from SSM",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When developing locally, set `process.env.NODE_ENV='local'` to use locally set `process.env` variables instead of `SSM`